### PR TITLE
Investigating code scanning issues

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.21-bullseye"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/cmd/github/github.go
+++ b/cmd/github/github.go
@@ -369,11 +369,14 @@ func EnableWorkflowsForRepository(organization string, repository string, workfl
 func HasCodeScanningAnalysis(organization string, repository string, token string) (bool, error) {
 	checkClients(token)
 
-	_, response, err := clientV3.CodeScanning.ListAlertsForRepo(ctx, organization, repository, nil)
+	_, response, err := clientV3.CodeScanning.ListAnalysesForRepo(ctx, organization, repository, nil)
 
 	logTokenRateLimit(response)
 
 	if err != nil {
+		// technically we can get a 403 error here as well when advanced security is not correctly enabled (this applies to archived repositories seen in the wild) 
+	    // but we do not appear to be hitting this error if code scanning has not been re-enabled on the target?
+
 		//test if error code is 404
 		if err, ok := err.(*github.ErrorResponse); ok {
 			if err.Response.StatusCode == 404 {

--- a/testing/test.go
+++ b/testing/test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+    "os"
+
+	"github.com/google/go-github/v55/github"
+	"golang.org/x/oauth2"
+)
+
+type RepoConfig struct {
+	token string
+	org   string
+	repo  string
+}
+
+func disableGHAS(ctx context.Context, client *github.Client, config RepoConfig) *github.Repository {
+	fmt.Println("Disabling GHAS code scanning")
+    repo := setCodeScanningState(ctx, client, config, "disabled")
+    return repo
+}
+
+func enableCodeScanning(ctx context.Context, client *github.Client, config RepoConfig) *github.Repository {
+    fmt.Println("Enabling GHAS code scanning")
+    repo := setCodeScanningState(ctx, client, config, "enabled")
+    return repo
+}
+
+func setCodeScanningState(ctx context.Context, client *github.Client, config RepoConfig, state string) *github.Repository {
+    disabled := "disabled"
+
+	payload := &github.SecurityAndAnalysis{
+		AdvancedSecurity: &github.AdvancedSecurity{
+			Status: &state,
+		},
+		SecretScanning: &github.SecretScanning{
+			Status: &disabled,
+		},
+		SecretScanningPushProtection: &github.SecretScanningPushProtection{
+			Status: &disabled,
+		},
+	}
+
+	//create new repository object
+	newRepoSettings := &github.Repository{
+		SecurityAndAnalysis: payload,
+	}
+
+	repo, resp, err := client.Repositories.Edit(ctx, config.org, config.repo, newRepoSettings)
+	if err != nil {
+		fmt.Println("Error updating repository GHAS settings")
+		fmt.Println(err)
+	}
+	fmt.Println("HTTP status for request: ", resp.Status)
+
+    return repo
+}
+
+func listCodeScanningAnalyses(ctx context.Context, client *github.Client, config RepoConfig) {
+	analyses, response, err := client.CodeScanning.ListAnalysesForRepo(ctx, config.org, config.repo, nil)
+	if err != nil {
+		fmt.Println("Error listing the code scanning analyses")
+		fmt.Println(err)
+		fmt.Println(" HTTP response: ", response.Status)
+	} else {
+		fmt.Println(response.Status)
+		for _, analysis := range analyses {
+			fmt.Printf("Analysis: %v, sarif id:%v\n", *analysis.ID, *analysis.SarifID)
+		}
+	}
+}
+
+func fetchRepository(ctx context.Context, client *github.Client, config RepoConfig) *github.Repository {
+    repo, _, err := client.Repositories.Get(ctx, config.org, config.repo)
+	if err != nil {
+        fmt.Println("Error fetching repository")
+		fmt.Println(err)
+        return nil
+	}
+
+	fmt.Println("Repository: ", *repo.Name)
+	fmt.Println("  is archived?   ", *repo.Archived)
+	fmt.Println("  GHAS enabled?  ", *repo.SecurityAndAnalysis.AdvancedSecurity.Status)
+
+    return repo
+}
+
+func main() {
+    config := new(RepoConfig)
+	config.org = "octodemo"
+	config.repo = "pm-bs-testing-8001"
+	config.token = os.Getenv("GH_TEST_TOKEN")
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: config.token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	client := github.NewClient(tc)
+
+	// Check the repository settings that we are starting out with
+	repo := fetchRepository(ctx, client, *config)
+
+    if (repo == nil) {
+        return;
+    }
+
+	if repo.SecurityAndAnalysis.AdvancedSecurity.Status == nil || *repo.SecurityAndAnalysis.AdvancedSecurity.Status == "enabled" {
+		// Switch to disabled
+		repo := disableGHAS(ctx, client, *config)
+		fmt.Println("  GHAS enabled?  ", *repo.SecurityAndAnalysis.AdvancedSecurity.Status)
+
+		fmt.Println("Pausing for settings to flush")
+		time.Sleep(10 * time.Second)
+	}
+
+    // This should fail to list
+    listCodeScanningAnalyses(ctx, client, *config)
+
+    // Re-enable GHAS code scanning
+    enableCodeScanning(ctx, client, *config)
+    time.Sleep(10 * time.Second) // Arbitary wait to ensure that things flush through
+    fmt.Println("-----------------------------------------------------")
+    fmt.Println("Checking repository GHAS settings")
+    fetchRepository(ctx, client, *config)
+    listCodeScanningAnalyses(ctx, client, *config)
+}


### PR DESCRIPTION
This PR contains the comments and issues that have been identified in the migration steps. It also fixes a bug of not using the correct endpoint for identifying whether there are analyses present.

There is a test file that I added has managed to capture the errors that can and do get generated when toggling the API for security and scanning features, we get 403 and 422 errors that the migration script will need to accommodate and might require some additional sleeping when the settings are toggled, which is present in the test script. Basically when run on the repository (you need to set an environment variable `GH_TES_TOKEN`) you will see the full end to end situation that needs to be built into the migration script steps.