### PR TITLE
Update logs to consider parallel workers

### DIFF
--- a/cmd/github/gei.go
+++ b/cmd/github/gei.go
@@ -2,7 +2,8 @@ package github
 
 import (
 	"errors"
-	"log"
+	"fmt"
+	"log/slog"
 	"math"
 	"os/exec"
 	"time"
@@ -16,7 +17,7 @@ func MigrateCodeScanning(repository string, sourceOrg string, targetOrg string, 
 	err := cmd.Run()
 
 	if err != nil {
-		log.Println("failed to migrate code scanning alerts: ", err)
+		slog.Error("failed to migrate code scanning alerts: ", err)
 		return err
 	}
 
@@ -29,7 +30,7 @@ func MigrateSecretScanning(repository string, sourceOrg string, targetOrg string
 	err := cmd.Run()
 
 	if err != nil {
-		log.Println("failed to migrate secret scanning remediations: ", err)
+		slog.Error("failed to migrate secret scanning remediations: ", err)
 		return err
 	}
 
@@ -44,7 +45,7 @@ func MigrateRepo(repository string, sourceOrg string, targetOrg string, sourceTo
 	err := cmd.Run()
 
 	if err != nil {
-		log.Println("failed to migrate repository: ", err)
+		slog.Error("failed to migrate repository: ", err)
 		return err
 	}
 
@@ -54,7 +55,7 @@ func MigrateRepo(repository string, sourceOrg string, targetOrg string, sourceTo
 	})
 
 	if err != nil {
-		log.Println("failed to migrate repository: ", err)
+		slog.Error("failed to migrate repository: ", err)
 		return err
 	}
 
@@ -67,7 +68,7 @@ func exponentialBackoff(fn func() (Repository, error)) error {
 		if err == nil {
 			return nil
 		} else {
-			log.Println("[⏳] retrying in", math.Pow(2, float64(i)), "seconds")
+			slog.Debug(fmt.Sprint("retrying in", math.Pow(2, float64(i)), "seconds"))
 		}
 		time.Sleep(time.Duration(math.Pow(2, float64(i))) * time.Second)
 	}

--- a/cmd/github/github.go
+++ b/cmd/github/github.go
@@ -3,7 +3,8 @@ package github
 import (
 	"context"
 	"errors"
-	"log"
+	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/gofri/go-github-ratelimit/github_ratelimit"
@@ -171,7 +172,7 @@ func ChangeGhasRepoSettings(organization string, repository Repository, ghas str
 	// Update the repository
 	_, response, err := clientV3.Repositories.Edit(ctx, organization, *repository.Name, &newRepoSettings)
 
-	log.Println("[⌛] Waiting 10 seconds for changes to apply...")
+	slog.Debug("waiting 10 seconds for changes to apply...")
 	time.Sleep(10 * time.Second)
 
 	if err != nil {
@@ -315,7 +316,7 @@ func DisableWorkflowsForRepository(organization string, repository string, workf
 		_, err := clientV3.Actions.DisableWorkflowByID(ctx, organization, repository, *workflow.ID)
 
 		if _, ok := err.(*github.ErrorResponse); ok {
-			log.Println("Failed to disable workflow: ", workflow.Name, " - will not stop migration")
+			slog.Debug(fmt.Sprint("failed to disable workflow: ", workflow.Name, " - will not stop migration"))
 			return nil
 		}
 	}

--- a/cmd/migrateRepo.go
+++ b/cmd/migrateRepo.go
@@ -4,7 +4,8 @@ Package cmd provides a command-line interface for changing GHAS settings for a g
 package cmd
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/gateixeira/gei-migration-helper/cmd/github"
@@ -39,19 +40,19 @@ var migrateRepoCmd = &cobra.Command{
 		repository, _ := cmd.Flags().GetString(repositoryFlagName)
 		maxRetries, _ := cmd.Flags().GetInt(maxRetriesFlagName)
 
-		log.Printf("Migrating repository %s from %s to %s", repository, sourceOrg, targetOrg)
+		slog.Info(fmt.Sprintf("migrating repository %s from %s to %s", repository, sourceOrg, targetOrg))
 
 		repo, err := github.GetRepository(repository, sourceOrg, sourceToken)
 
 		if err != nil {
-			log.Println("[❌] Error getting source repository: " + repository)
+			slog.Info("error getting source repository: " + repository)
 			os.Exit(1)
 		}
 
 		err = ProcessRepoMigration(repo, sourceOrg, targetOrg, sourceToken, targetToken, maxRetries)
 
 		if err != nil {
-			log.Println("[❌] Error migrating repository: " + repository)
+			slog.Error("error migrating repository: " + repository)
 			os.Exit(1)
 		}
 	},

--- a/cmd/migrateSecretScanning.go
+++ b/cmd/migrateSecretScanning.go
@@ -4,7 +4,9 @@ Package cmd provides a command-line interface for changing GHAS settings for a g
 package cmd
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
+	"os"
 
 	"github.com/gateixeira/gei-migration-helper/cmd/github"
 	"github.com/spf13/cobra"
@@ -21,18 +23,18 @@ var migrateSecretScanningCmd = &cobra.Command{
 		targetToken, _ := cmd.Flags().GetString(targetTokenFlagName)
 		repository, _ := cmd.Flags().GetString(repositoryFlagName)
 
-		log.Printf("Migrating secret scanning for repository %s from %s to %s", repository, sourceOrg, targetOrg)
+		slog.Info(fmt.Sprintf("migrating secret scanning for repository %s from %s to %s", repository, sourceOrg, targetOrg))
 
 		if repository == "" {
-			log.Println("\n[🔄] Fetching repositories from source organization")
+			slog.Info("fetching repositories from source organization")
 			repositories, err := github.GetRepositories(sourceOrg, sourceToken)
 
 			if err != nil {
-				log.Println("[❌] Error fetching repositories from source organization")
-				return
+				slog.Error("error fetching repositories from source organization")
+				os.Exit(1)
 			}
 
-			log.Println("[✅] Done")
+			slog.Info("done")
 
 			for _, repository := range repositories {
 				if *repository.Name == ".github" {
@@ -41,7 +43,7 @@ var migrateSecretScanningCmd = &cobra.Command{
 				err := CheckAndMigrateSecretScanning(*repository.Name, sourceOrg, targetOrg, sourceToken, targetToken)
 
 				if err != nil {
-					log.Printf("[❌] Error migrating secret scanning for repository: " + *repository.Name)
+					slog.Error("error migrating secret scanning for repository: " + *repository.Name)
 					continue
 				}
 			}
@@ -49,8 +51,8 @@ var migrateSecretScanningCmd = &cobra.Command{
 			err := CheckAndMigrateSecretScanning(repository, sourceOrg, targetOrg, sourceToken, targetToken)
 
 			if err != nil {
-				log.Printf("[❌] Error migrating secret scanning for repository: " + repository)
-				return
+				slog.Error("error migrating secret scanning for repository: " + repository)
+				os.Exit(1)
 			}
 		}
 	},

--- a/cmd/reactivateTargetWorkflows.go
+++ b/cmd/reactivateTargetWorkflows.go
@@ -4,7 +4,8 @@ Package cmd provides a command-line interface for changing GHAS settings for a g
 package cmd
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 
 	"github.com/gateixeira/gei-migration-helper/cmd/github"
 	"github.com/spf13/cobra"
@@ -21,18 +22,18 @@ var reactivateTargetWorkflowsCmd = &cobra.Command{
 		targetToken, _ := cmd.Flags().GetString(targetTokenFlagName)
 		repository, _ := cmd.Flags().GetString(repositoryFlagName)
 
-		log.Printf("Reactivating target workflows for repository %s from %s to %s", repository, sourceOrg, targetOrg)
+		slog.Info(fmt.Sprintf("reactivating target workflows for repository %s from %s to %s", repository, sourceOrg, targetOrg))
 
 		if repository == "" {
-			log.Println("\n[🔄] Fetching repositories from source organization")
+			slog.Info("fetching repositories from source organization")
 			repositories, err := github.GetRepositories(sourceOrg, sourceToken)
 
 			if err != nil {
-				log.Println("[❌] Error fetching repositories from source organization")
+				slog.Error("error fetching repositories from source organization")
 				return
 			}
 
-			log.Println("[✅] Done")
+			slog.Info("done")
 
 			for _, repository := range repositories {
 				if *repository.Name == ".github" {
@@ -42,7 +43,7 @@ var reactivateTargetWorkflowsCmd = &cobra.Command{
 				err := ReactivateTargetWorkflows(*repository.Name, sourceOrg, targetOrg, sourceToken, targetToken)
 
 				if err != nil {
-					log.Printf("[❌] Error migrating secret scanning for repository: " + *repository.Name)
+					slog.Error("error migrating secret scanning for repository: " + *repository.Name)
 					continue
 				}
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const VERSION = "0.1.2"
+const VERSION = "1.1.0"
 
 const (
 	sourceOrgFlagName   = "source-org"
@@ -22,6 +22,8 @@ const (
 
 //go:embed banner.txt
 var banner []byte
+
+var enableDebug bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -36,20 +38,17 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	err := rootCmd.Execute()
+
 	if err != nil {
 		os.Exit(1)
 	}
 }
 
 func init() {
-	rootCmd.SetOut(os.Stdout)
-	rootCmd.SetErr(os.Stderr)
-	rootCmd.Version = VERSION
-	rootCmd.Println("\n\n" + string(banner) + "\n\n")
-
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
+	rootCmd.PersistentFlags().BoolVar(&enableDebug, "debug", os.Getenv("DEBUG") == "true", "Enable debug mode")
 
 	rootCmd.PersistentFlags().String(sourceOrgFlagName, "", "The source organization.")
 	rootCmd.MarkPersistentFlagRequired(sourceOrgFlagName)

--- a/main.go
+++ b/main.go
@@ -1,10 +1,8 @@
-/*
-Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-
-*/
 package main
 
-import "github.com/gateixeira/gei-migration-helper/cmd"
+import (
+	"github.com/gateixeira/gei-migration-helper/cmd"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
This pull request primarily involves changes to improve logging across multiple files in the codebase. The changes replace the standard `log` package with `slog` for structured logging, and use `fmt` for string formatting. The changes are spread across multiple functions and methods in the files `gei.go`, `github.go`, `migrateOrg.go`, `migrateRepo.go`, `migrateSecretScanning.go`, `migrationStatus.go`, and `migrationSteps.go`.